### PR TITLE
feat: enable prehash to secure password length

### DIFF
--- a/dto/dto.user.go
+++ b/dto/dto.user.go
@@ -54,7 +54,7 @@ type ResponseLogin struct {
 	Token string `json:"token"`
 }
 
-type ResposneGetProfile struct {
+type ResponseGetProfile struct {
 	Email           string `json:"email"`
 	Name            string `json:"name"`
 	UserImageUri    string `json:"userImageUri"`

--- a/helper/constant.go
+++ b/helper/constant.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"errors"
+	"net/http"
 )
 
 type FunctionCaller string
@@ -47,6 +48,6 @@ var ErrorInternalServerError = errors.New("internal server error")
 
 var ErrorEmailRegistered = errors.New("email is already registered")
 var ErrorUsernameRegistered = errors.New("username is already registered")
-var ErrorInvalidLogin = errors.New("invalid email or password")
+var ErrorInvalidLogin = NewErrorResponse(http.StatusBadRequest, "invalid email or password")
 
 var WORK_DIR string


### PR DESCRIPTION
@DanyAdhi originally identified a critical bug in which users could obtain tokens even after entering incorrect passwords. During the investigation, we discovered an underlying issue with bcrypt: it only supports passwords up to 72 bytes. This limitation caused problems for users with passwords longer than 72 characters, as their passwords were being truncated, leading to login failures and the inability to create new accounts.

**Solution**
To address this issue, we introduced a preprocessing step using the SHA256 algorithm:

- Pre-hashing: All passwords are first hashed using SHA256 before being passed to bcrypt. This ensures that the input to bcrypt is always a consistent 32 bytes, regardless of the original password length.
- This approach retains compatibility with bcrypt for secure password storage while removing the 72-byte password length limitation.

**Impact**
- Users with long passwords can now log in or create accounts without encountering errors.
- Existing users with passwords shorter than 72 bytes are unaffected as the new logic is backward-compatible.
- Improved overall security by standardizing input to bcrypt.